### PR TITLE
fix: choose high performance adapter for our game. 

### DIFF
--- a/core-rust/natives/src/window_surface.rs
+++ b/core-rust/natives/src/window_surface.rs
@@ -29,7 +29,7 @@ impl WindowSurface {
     pub async fn new(instance: &wgpu::Instance, surface: wgpu::Surface ) -> WindowSurface {
         let adapter = instance 
             .request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::default(),
+                power_preference: wgpu::PowerPreference::HighPerformance,
                 force_fallback_adapter: false,
                 // Request an adapter which can render to our surface
                 compatible_surface: Some(&surface),


### PR DESCRIPTION
wgpu's PowerPreference::default() provide LowPower device by default.
LowPower is IntegrateGPU often.

Testing:
Requirements: 
1. Two Gpus - Integrated and discrete
2. not hybrid graphics (not laptop)

Steps:
1. run game
2. should shows main menu 
3. should logs like:
```
Used device info: 
name: NVIDIA or AMD
vendor: ...
device_type: DescreteGpu // <--- there
device: ...
backend: Vulkan
```

