### PR TITLE
fix: fix building and running under Windows

### DIFF
--- a/core-rust/build.gradle
+++ b/core-rust/build.gradle
@@ -19,8 +19,12 @@ ext {
         natives = [
                 [target: "x86_64-unknown-linux-gnu", module: "linux-amd64"]
         ]
+    } else if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        natives = [
+                [target: "x86_64-pc-windows-msvc", "module": "windows-amd64"]
+        ]
     } else {
-        throw new GradleException("This script only works on Linux or Mac")
+        throw new GradleException("Unsupported platform")
     }
 
     baseDir = "$rootDir/core-rust"
@@ -66,7 +70,9 @@ natives.each { module ->
             copy {
                 from "$baseDir/natives/target/${module["target"]}/debug"
                 include '*.so'
+                include '*.dll'
                 rename '(.+).so', "\$1-${module["module"]}.so"
+                rename '(.+).dll', "lib\$1-${module["module"]}.dll"
                 into "$baseDir/build/natives"
             }
         }

--- a/core-rust/natives/src/window_surface.rs
+++ b/core-rust/natives/src/window_surface.rs
@@ -1,4 +1,4 @@
-use core::ffi::c_void;
+use core::ffi::{c_void, c_ulong};
 
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle, Win32WindowHandle, WindowsDisplayHandle, XlibDisplayHandle, XlibWindowHandle};
 
@@ -106,7 +106,7 @@ impl WindowSurface {
             }
         }
 
-        window.window.window = window_ptr as u64;
+        window.window.window = window_ptr as c_ulong;
         window.display.display = display_ptr as *mut c_void;
         
         let surface_result = unsafe {instance.create_surface(&window) };


### PR DESCRIPTION
These changes should allow for compiling and running the code under Windows.

Whilst `x86_64-pc-windows-gnu` is a valid platform, these changes use the `x86_64-pc-windows-msvc` for the moment.  `x86_64-pc-windows-gnu` may be a more suitable target if cross-compiling from Linux in the future.