### PR TITLE
Allow wgpu logging and forced backend using environment variables

### DIFF
--- a/core-rust/natives/Cargo.toml
+++ b/core-rust/natives/Cargo.toml
@@ -18,3 +18,6 @@ slotmap = "1.0.6"
 glam = "0.24.1"
 smallvec = "1.11.0"
 bytemuck = {version = "1.13.1", features = ["derive"]}
+
+log = "0.4.0"
+env_logger = "0.10.0"

--- a/core-rust/natives/src/jni/jni_engine_kernel.rs
+++ b/core-rust/natives/src/jni/jni_engine_kernel.rs
@@ -15,6 +15,7 @@ enum JavaWindowType {
 
 #[no_mangle]
 pub extern "system" fn Java_org_terasology_engine_rust_EngineKernel_00024JNI_create<'local>(mut env: JNIEnv<'local>, _class: JClass, desc: JObject<'local>) -> jlong  {
+    env_logger::init();
     let window_type = env.get_field(&desc, "windowType", "I").unwrap().i().unwrap() ;
     let display_ptr = env.get_field(&desc, "displayHandle", "J").unwrap().j().unwrap() ;
     let window_ptr = env.get_field(&desc, "windowHandle", "J").unwrap().j().unwrap() ;

--- a/core-rust/natives/src/jni/jni_engine_kernel.rs
+++ b/core-rust/natives/src/jni/jni_engine_kernel.rs
@@ -46,7 +46,10 @@ pub extern "system" fn Java_org_terasology_engine_rust_EngineKernel_00024JNI_cre
         window: window_desc 
     };
 
-    let instance = wgpu::Instance::default();
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::util::backend_bits_from_env().unwrap_or_else(wgpu::Backends::all),
+        ..Default::default()
+    });
     return EngineKernel::to_handle(Arc::new(EngineKernel::new(instance, &EngineKernelDesc {
         surface: window_surface_desc
     })));

--- a/core-rust/natives/src/lib.rs
+++ b/core-rust/natives/src/lib.rs
@@ -5,3 +5,6 @@ mod ui;
 mod resource;
 mod jni;
 mod math;
+
+#[macro_use]
+extern crate log;


### PR DESCRIPTION
This pull request enables wgpu logging by adding a dependency on the `log` and `env_logger` crates. It allows you to enable full debug logging by setting the `RUST_LOG=debug` environment variable.

This pull request also modifies the wgpu backend selection to respect the `WGPU_BACKEND` environment variable. This allows for forcing the chosen wgpu backend in cases where the default does not work.